### PR TITLE
fix: return errors on read callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,12 +268,19 @@ Unregister the read raw callback
 | **`readRaw`** | <code>boolean</code> |
 
 
+#### SerialErrorWrapper
+
+| Prop          | Type                                                |
+| ------------- | --------------------------------------------------- |
+| **`message`** | <code><a href="#serialerror">SerialError</a></code> |
+
+
 ### Type Aliases
 
 
 #### SerialReadCallback
 
-<code>(message: <a href="#serialmessage">SerialMessage</a>, error?: <a href="#serialerror">SerialError</a>): void</code>
+<code>(message: <a href="#serialmessage">SerialMessage</a>, error?: <a href="#serialerrorwrapper">SerialErrorWrapper</a>): void</code>
 
 
 ### Enums

--- a/android/src/main/java/com/adeunis/capacitor/serial/SerialPlugin.kt
+++ b/android/src/main/java/com/adeunis/capacitor/serial/SerialPlugin.kt
@@ -348,15 +348,11 @@ class SerialPlugin : Plugin() {
     private fun onSerialIoRunError() {
         val readCallback = readCallback;
         if (readCallback != null) {
-            val response = JSObject()
-            response.put("error", CONNECTION_ERROR)
-            readCallback.resolve(response)
+            readCallback.reject(CONNECTION_ERROR)
         }
         val readRawCallback = readRawCallback;
         if (readRawCallback != null) {
-            val response = JSObject()
-            response.put("error", CONNECTION_ERROR)
-            readRawCallback.resolve(response)
+            readRawCallback.reject(CONNECTION_ERROR)
         }
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -41,8 +41,12 @@ export enum SerialError {
     PORT_CLOSED_ERROR = "PORT_CLOSED_ERROR"
 }
 
+export interface SerialErrorWrapper extends Error {
+    message: SerialError
+}
 
-export type SerialReadCallback = (message: SerialMessage | undefined, error?: SerialError) => void;
+
+export type SerialReadCallback = (message: SerialMessage | undefined, error?: SerialErrorWrapper) => void;
 
 
 export interface SerialPlugin {


### PR DESCRIPTION
I'm trying to detect when a device gets disconnected by unplugging the USB cable and noticed there is a `CONNECTION_ERROR` when this happens. Currently, these errors are returned with `resolve`, which means the `SerialMessage` object has an optional `error` property, which is not accessible due to the current typing. I think changing it to `reject` is a better option, but then it becomes an actual `Error` object, so I also used `SerialErrorWrapper` to keep the definition of `SerialError` backwards compatible. Maybe this should still be marked as a breaking change in case anybody is already using custom types to access the current `error` property.

I also tried to play with [UsbManager.ACTION_USB_DEVICE_DETACHED](https://developer.android.com/develop/connectivity/usb/host#terminating-d), but then it gets more complicated (need to handle `onPause`/`onResume`, unregister the receiver etc). Do you know any other instances when a `CONNECTION_ERROR` could occur, besides unplugging the device or could this be a safe solution?